### PR TITLE
Add "applyDefaultIcon" setting

### DIFF
--- a/openbox/client.c
+++ b/openbox/client.c
@@ -2241,15 +2241,20 @@ void client_update_icons(ObClient *self)
         while (i + 2 < num) { /* +2 is to make sure there is a w and h */
             w = data[i++];
             h = data[i++];
+            /* calculate the data size as guint64 to prevent integer
+               overflow due to invalid data */
+            guint64 size = w * h;
             /* watch for the data being too small for the specified size,
                or for zero sized icons. */
-            if (i + w*h > num || w == 0 || h == 0) {
-                i += w*h;
+            if (i + size > num || size < w || size < h) {
+                break;
+            } else if (w == 0 || h == 0) {
+                i += size;
                 continue;
             }
 
             /* convert it to the right bit order for ObRender */
-            for (j = 0; j < w*h; ++j)
+            for (j = 0; j < size; ++j)
                 data[i+j] =
                     (((data[i+j] >> 24) & 0xff) << RrDefaultAlphaOffset) +
                     (((data[i+j] >> 16) & 0xff) << RrDefaultRedOffset)   +
@@ -2262,7 +2267,7 @@ void client_update_icons(ObClient *self)
             else
                 RrImageAddFromData(img, &data[i], w, h);
 
-            i += w*h;
+            i += size;
         }
 
         g_free(data);

--- a/openbox/client.c
+++ b/openbox/client.c
@@ -2306,7 +2306,7 @@ void client_update_icons(ObClient *self)
     /* if the client has no icon at all, then we set a default icon onto it.
        but, if it has parents, then one of them will have an icon already
     */
-    if (!self->icon_set && !self->parents) {
+    if (!self->icon_set && !self->parents && config_apply_default_icon) {
         RrPixel32 *icon = ob_rr_theme->def_win_icon;
         gulong *ldata; /* use a long here to satisfy OBT_PROP_SETA32 */
 

--- a/openbox/config.c
+++ b/openbox/config.c
@@ -50,6 +50,7 @@ gboolean config_theme_keepborder;
 guint    config_theme_window_list_icon_size;
 
 gchar   *config_title_layout;
+gboolean config_apply_default_icon;
 
 gboolean config_animate_iconify;
 
@@ -712,6 +713,8 @@ static void parse_theme(xmlNodePtr node, gpointer d)
         config_theme_keepborder = obt_xml_node_bool(n);
     if ((n = obt_xml_find_node(node, "animateIconify")))
         config_animate_iconify = obt_xml_node_bool(n);
+    if ((n = obt_xml_find_node(node, "applyDefaultIcon")))
+        config_apply_default_icon = obt_xml_node_bool(n);
     if ((n = obt_xml_find_node(node, "windowListIconSize"))) {
         config_theme_window_list_icon_size = obt_xml_node_int(n);
         if (config_theme_window_list_icon_size < 16)
@@ -1098,6 +1101,7 @@ void config_startup(ObtXmlInst *i)
     config_title_layout = g_strdup("NLIMC");
     config_theme_keepborder = TRUE;
     config_theme_window_list_icon_size = 36;
+    config_apply_default_icon = TRUE;
 
     config_font_activewindow = NULL;
     config_font_inactivewindow = NULL;

--- a/openbox/config.h
+++ b/openbox/config.h
@@ -152,6 +152,8 @@ extern gchar *config_title_layout;
 extern gboolean config_animate_iconify;
 /*! Size of icons in focus switching dialogs */
 extern guint config_theme_window_list_icon_size;
+/*! Set a default icon for windows that lack one */
+extern gboolean config_apply_default_icon;
 
 /*! The font for the active window's title */
 extern RrFont *config_font_activewindow;


### PR DESCRIPTION
Some applications don't provide their own icons. By default, Openbox sets a generic icon for these applications. Other environments, such as GNOME, instead supply an icon from /usr/share/pixmaps or the icon theme. Openbox's behavior is appropriate when it is running on its own, but when it is being used as the window manager in a broader desktop environment, the presence of the default icon prevents the environment from noticing that it needs to provide an icon.

This change adds an `<applyDefaultIcon>` configuration option that defaults to `yes` to preserve the standard Openbox behavior. By setting this option to `no`, Openbox will cede responsibility for setting default icons to the desktop environment.

Resolves issue #21