### PR TITLE
openbox/event: optimize motion event compression

### DIFF
--- a/obt/xqueue.c
+++ b/obt/xqueue.c
@@ -71,7 +71,7 @@ static inline void grow(void) {
     if (qnum == qsz) {
         const gulong newsz = qsz*2;
         gulong i;
- 
+
         q = g_renew(XEvent, q, newsz);
 
         g_assert(qnum > 0);
@@ -314,9 +314,130 @@ gboolean xqueue_remove_local(XEvent *event_return,
 gboolean xqueue_pending_local(void)
 {
     g_return_val_if_fail(q != NULL, FALSE);
-    
+
     if (!qnum) read_events(FALSE);
     return qnum != 0;
+}
+
+/* Remove events at specific physical indices in q
+ * indices_to_remove must contain indices in [0, qsz)
+ */
+static void xqueue_remove_at_indices(gulong *indices_to_remove,
+                                     gulong  num_to_remove)
+{
+    XEvent *new_q;
+    gchar *remove_mask; /* Using char as boolean array */
+    gulong i, new_idx;
+    gulong k;
+
+    if (num_to_remove == 0 || qnum == 0)
+        return;
+
+    /* Create a mask for O(1) lookup during iteration */
+    remove_mask = g_new0(gchar, qsz);
+    for (k = 0; k < num_to_remove; ++k) {
+        if (indices_to_remove[k] < qsz)
+            remove_mask[indices_to_remove[k]] = 1;
+    }
+
+    new_q = g_new(XEvent, qsz);
+    new_idx = 0;
+
+    for (i = 0; i < qnum; ++i) {
+        gulong current_q_idx = (qstart + i) % qsz;
+
+        if (!remove_mask[current_q_idx]) {
+            new_q[new_idx++] = q[current_q_idx];
+        }
+    }
+
+    g_free(remove_mask);
+    g_free(q);
+    q = new_q;
+    qnum = new_idx;
+    qstart = 0; /* Queue is now contiguous starting at 0 */
+    qend = (qnum == 0) ? (gulong)-1 : (qnum - 1);
+
+    shrink();
+}
+
+gboolean xqueue_remove_all_but_last_motion_event(XEvent *event_return,
+                                                 Window window)
+{
+    gulong last_motion_event_q_idx;
+    GSList *indices_to_remove_list;
+    gboolean motion_event_found;
+    gulong i;
+
+    g_return_val_if_fail(q != NULL, FALSE);
+    g_return_val_if_fail(event_return != NULL, FALSE);
+
+    if (!qnum)
+        read_events(FALSE);
+
+    last_motion_event_q_idx = (gulong)-1;
+    indices_to_remove_list = NULL;
+    motion_event_found = FALSE;
+
+    /* find all MotionNotify events for this window, track last index,
+     * and collect previous ones into indices_to_remove_list
+     */
+    for (i = 0; i < qnum; ++i) {
+        gulong current_q_logical_idx = (qstart + i) % qsz;
+        XEvent *current_event = &q[current_q_logical_idx];
+
+        if (current_event->type == MotionNotify &&
+            current_event->xmotion.window == window) {
+
+            if (last_motion_event_q_idx != (gulong)-1) {
+                indices_to_remove_list =
+                    g_slist_prepend(indices_to_remove_list,
+                                    GUINT_TO_POINTER((guint)last_motion_event_q_idx));
+            }
+
+            last_motion_event_q_idx = current_q_logical_idx;
+            motion_event_found = TRUE;
+        }
+    }
+
+    if (!motion_event_found) {
+        g_slist_free(indices_to_remove_list);
+        return FALSE;
+    }
+
+    /* copy last motion event before mutating the queue */
+    *event_return = q[last_motion_event_q_idx];
+
+    /* also remove the last one so the queue no longer has any matching MotionNotify */
+    indices_to_remove_list =
+        g_slist_prepend(indices_to_remove_list,
+                        GUINT_TO_POINTER((guint)last_motion_event_q_idx));
+
+    {
+        gulong num_to_remove = g_slist_length(indices_to_remove_list);
+
+        if (num_to_remove > 0) {
+            gulong *indices_array;
+            GSList *current_node;
+            gulong idx;
+
+            indices_array = g_new(gulong, num_to_remove);
+            current_node = indices_to_remove_list;
+            idx = 0;
+
+            while (current_node != NULL) {
+                indices_array[idx++] =
+                    (gulong)GPOINTER_TO_UINT(current_node->data);
+                current_node = g_slist_next(current_node);
+            }
+
+            xqueue_remove_at_indices(indices_array, num_to_remove);
+            g_free(indices_array);
+        }
+    }
+
+    g_slist_free(indices_to_remove_list);
+    return TRUE;
 }
 
 typedef struct _ObtXQueueCB {

--- a/obt/xqueue.h
+++ b/obt/xqueue.h
@@ -87,6 +87,12 @@ gboolean xqueue_exists_local(xqueue_match_func match, gpointer data);
 gboolean xqueue_remove_local(XEvent *event_return,
                              xqueue_match_func match, gpointer data);
 
+/* Removes all MotionNotify events for a given window from the queue.
+ * The last such event is stored in event_return and not requeued.
+ * Returns TRUE if at least one MotionNotify event was found. */
+gboolean xqueue_remove_all_but_last_motion_event(XEvent *event_return,
+                                                 Window window);
+
 typedef void (*ObtXQueueFunc)(const XEvent *ev, gpointer data);
 
 /*! Begin listening for X events in the default GMainContext, and feed them

--- a/openbox/event.c
+++ b/openbox/event.c
@@ -301,16 +301,14 @@ static void event_hack_mods(XEvent *e)
         e->xmotion.state = obt_keyboard_only_modmasks(e->xmotion.state);
         /* compress events */
         {
-            XEvent ce;
-            ObtXQueueWindowType wt;
-
-            wt.window = e->xmotion.window;
-            wt.type = MotionNotify;
-            while (xqueue_remove_local(&ce, xqueue_match_window_type, &wt)) {
-                e->xmotion.x = ce.xmotion.x;
-                e->xmotion.y = ce.xmotion.y;
-                e->xmotion.x_root = ce.xmotion.x_root;
-                e->xmotion.y_root = ce.xmotion.y_root;
+            XEvent last_motion_event;
+            /* compress queued MotionNotify events for this window into one */
+            if (xqueue_remove_all_but_last_motion_event(&last_motion_event, e->xmotion.window)) {
+                /* update the current event with the last queued position */
+                e->xmotion.x = last_motion_event.xmotion.x;
+                e->xmotion.y = last_motion_event.xmotion.y;
+                e->xmotion.x_root = last_motion_event.xmotion.x_root;
+                e->xmotion.y_root = last_motion_event.xmotion.y_root;
             }
         }
         break;


### PR DESCRIPTION
This patch implements bulk removal of stale MotionNotify events to reduce event processing overhead.

Previously, event compression removed stale events one by one using `xqueue_remove_local`. This required shifting the array elements O(N) for every stale event found, leading to approximately O(N^2) complexity. With high-polling rate mice (1000Hz+), this resulted in significant CPU usage and UI lag during window drags.

The new `xqueue_remove_all_but_last_motion_event` function identifies all stale events in a single pass and rebuilds the queue once using a mask-based approach. This reduces the complexity to O(N) and handles the circular buffer wrapping safely.